### PR TITLE
StackOverflowError when there are too many commits fix

### DIFF
--- a/src/main/java/de/fhg/igd/mongomvcc/impl/internal/Index.java
+++ b/src/main/java/de/fhg/igd/mongomvcc/impl/internal/Index.java
@@ -17,6 +17,7 @@
 
 package de.fhg.igd.mongomvcc.impl.internal;
 
+import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -69,39 +70,45 @@ public class Index {
 	}
 	
 	/**
-	 * Recursively reads the information from the given commit and all its
+	 * Iteratively reads the information from the given commit and all its
 	 * ancestors and builds up the index
 	 * @param c the commit to read
 	 * @param tree the tree of commits
 	 */
 	private void readCommit(Commit c, Tree tree) {
-		if (c.getParentCID() != 0) {
-			//recursively read parent commit (if there is any)
-			Commit parent = tree.resolveCommit(c.getParentCID());
-			readCommit(parent, tree);
+		ArrayDeque<Commit> stack = new ArrayDeque<Commit>();
+		while (true) {
+			//iteratively read parent commit (if there is any)
+			stack.addLast(c);
+			long cid = c.getParentCID();
+			if (cid == 0)
+				break;
+			c = tree.resolveCommit(cid);
 		}
-
-		//read objects from the given commit and put them into the index
-		for (Map.Entry<String, IdMap> e : c.getObjects().entrySet()) {
-			IdMap m = getObjects(e.getKey());
-			IdSet o = getOIDs(e.getKey());
-			IdMapIterator it = e.getValue().iterator();
-			while (it.hasNext()) {
-				it.advance();
-				if (it.value() < 0) {
-					//deleted object
-					long prev = m.get(it.key());
-					if (prev != 0) {
-						m.remove(it.key());
-						o.remove(prev);
+		while (!stack.isEmpty()) {
+			c = stack.removeLast();
+			//read objects from the given commit and put them into the index
+			for (Map.Entry<String, IdMap> e : c.getObjects().entrySet()) {
+				IdMap m = getObjects(e.getKey());
+				IdSet o = getOIDs(e.getKey());
+				IdMapIterator it = e.getValue().iterator();
+				while (it.hasNext()) {
+					it.advance();
+					if (it.value() < 0) {
+						//deleted object
+						long prev = m.get(it.key());
+						if (prev != 0) {
+							m.remove(it.key());
+							o.remove(prev);
+						}
+					} else {
+						long prev = m.put(it.key(), it.value());
+						if (prev != 0) {
+							//overwrite object with new value
+							o.remove(prev);
+						}
+						o.add(it.value());
 					}
-				} else {
-					long prev = m.put(it.key(), it.value());
-					if (prev != 0) {
-						//overwrite object with new value
-						o.remove(prev);
-					}
-					o.add(it.value());
 				}
 			}
 		}

--- a/src/test/java/de/fhg/igd/mongomvcc/impl/internal/IndexTest.java
+++ b/src/test/java/de/fhg/igd/mongomvcc/impl/internal/IndexTest.java
@@ -1,0 +1,72 @@
+package de.fhg.igd.mongomvcc.impl.internal;
+
+import de.fhg.igd.mongomvcc.VBranch;
+import de.fhg.igd.mongomvcc.VCollection;
+import de.fhg.igd.mongomvcc.VConstants;
+import de.fhg.igd.mongomvcc.VDatabase;
+import de.fhg.igd.mongomvcc.impl.AbstractMongoDBVDatabaseTest;
+import de.fhg.igd.mongomvcc.impl.MongoDBVDatabase;
+import java.util.ArrayList;
+import java.util.Map;
+import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+
+public class IndexTest extends AbstractMongoDBVDatabaseTest {
+	/**
+	 * This test checks if indexes are loaded in the correct order: oldest should be first, newest come later.
+	 */
+	@Test
+	public void loadingOrder() {
+		VCollection persons = _master.getCollection( "persons" );
+		Map< String, Object > elvis = _factory.createDocument();
+		elvis.put( "name", "elvis" );
+		elvis.put( "age", "2" );
+		persons.insert( elvis );
+		Map< String, Object > max = _factory.createDocument();
+		max.put( "name", "max" );
+		max.put( "age", "3" );
+		persons.insert( max );
+		long first = _master.commit();
+		ArrayList< String > beforeInSession = new ArrayList<>();
+		for ( Map< String, Object > person : persons.find() )
+			beforeInSession.add( person.toString() );
+		elvis.put( "age", "4" );
+		persons.insert(elvis );
+		long second = _master.commit();
+		ArrayList< String > afterInSession = new ArrayList<>();
+		for ( Map< String, Object > person : persons.find() )
+			afterInSession.add( person.toString() );
+		VBranch oldMaster = _db.checkout( first );
+		VCollection oldWells = oldMaster.getCollection( "persons" );
+		ArrayList< String > beforeOutOfSession = new ArrayList<>();
+		for ( Map< String, Object > person : oldWells.find() )
+			beforeOutOfSession.add( person.toString() );
+		VBranch newMaster = _db.checkout( second );
+		VCollection newWells = newMaster.getCollection( "persons" );
+		ArrayList< String > afterOutOfSession = new ArrayList<>();
+		for ( Map< String, Object > person : newWells.find() )
+			afterOutOfSession.add( person.toString() );
+		assertArrayEquals( beforeInSession.toArray(), beforeOutOfSession.toArray() );
+		assertArrayEquals( afterInSession.toArray(), afterOutOfSession.toArray() );
+	}
+	
+	/**
+	 * This test checks if a stack overflows when there are too many commits in the database.
+	 * @throws StackOverflowError if the test fails
+	 */
+	@Test
+	public void stackOverflow() throws StackOverflowError {
+		VCollection persons = _master.getCollection( "stack" );
+		Map< String, Object > elvis = _factory.createDocument();
+		elvis.put( "name", "elvis" );
+		for ( int i = 0; i < 2500; i++ ) {
+			persons.insert( elvis );
+			_master.commit();
+		}
+		VDatabase db = _factory.createDatabase();
+		db.connect( ( ( MongoDBVDatabase )_db ).getDB().getName() );
+		VBranch master = db.checkout( VConstants.MASTER );
+		persons = master.getCollection( "stack" );
+		persons.find().size();
+	}
+}


### PR DESCRIPTION
A StackOverflowError occurs if there are too many commits in the database while reading indexes recursively. An iterative approach eliminates this problem. Also, there's a test to check it. But it's slow due to the need of many fsync commits. It just shows a current error and can be ignored after applying the fix.
